### PR TITLE
CustomError 으로 상태코드, 에러메시지 전달하도록 클래스 추가

### DIFF
--- a/api/controllers/comments.controller.js
+++ b/api/controllers/comments.controller.js
@@ -1,3 +1,4 @@
+const { BadRequestError } = require("../middlewares/customError.js");
 const CommentsService = require("../services/comments.service.js");
 
 module.exports = class CommentsController {
@@ -12,7 +13,7 @@ module.exports = class CommentsController {
 
     try {
       if (!(postId && comment)) {
-        throw new Error("댓글 작성에 실패하였습니다.");
+        throw new BadRequestError("적절하지 않은 파라미터 요청입니다.");
       }
       const result = await this.commentsService.createComment({
         userId,
@@ -31,7 +32,7 @@ module.exports = class CommentsController {
 
     try {
       if (!postId) {
-        throw new Error("댓글 목록 조회에 실패하였습니다.");
+        throw new BadRequestError("적절하지 않은 파라미터 요청입니다.");
       }
       const result = await this.commentsService.getCommentsByPost({
         postId,
@@ -50,7 +51,7 @@ module.exports = class CommentsController {
 
     try {
       if (!(commentId && comment)) {
-        throw new Error("댓글 수정에 실패하였습니다.");
+        throw new BadRequestError("적절하지 않은 파라미터 요청입니다.");
       }
       const result = await this.commentsService.editComment({
         userId,
@@ -70,7 +71,7 @@ module.exports = class CommentsController {
 
     try {
       if (!commentId) {
-        throw new Error("댓글 삭제에 실패하였습니다.");
+        throw new BadRequestError("적절하지 않은 파라미터 요청입니다.");
       }
       const result = await this.commentsService.deleteComment({
         userId,

--- a/api/middlewares/error.middleware.js
+++ b/api/middlewares/error.middleware.js
@@ -1,4 +1,5 @@
 module.exports = (err, req, res, next) => {
   console.error("\x1b[31m%s\x1b[0m", err);
-  return res.status(400).json({ message: err.message });
+  const code = err.statusCode ? err.statusCode : 500;
+  return res.status(code).json({ message: err.message });
 };

--- a/api/services/comments.service.js
+++ b/api/services/comments.service.js
@@ -1,3 +1,7 @@
+const {
+  NotFoundError,
+  ForbiddenError,
+} = require("../middlewares/customError.js");
 const CommentsRepository = require("../repositories/comments.repository.js");
 
 module.exports = class CommentsService {
@@ -16,7 +20,7 @@ module.exports = class CommentsService {
     if (!result) {
       throw new Error("댓글 작성에 실패하였습니다.");
     }
-    return { success: true, message: "댓글이 생성되었습니다." };
+    return { message: "댓글이 생성되었습니다." };
   };
 
   // 댓글 목록 조회
@@ -28,7 +32,7 @@ module.exports = class CommentsService {
     if (!comments) {
       throw new Error("댓글 목록 조회에 실패하였습니다.");
     }
-    return { success: true, comments };
+    return { data: comments };
   };
 
   // 댓글 수정
@@ -37,10 +41,11 @@ module.exports = class CommentsService {
       commentId,
     });
     if (!existComment) {
-      throw new Error("댓글 조회에 실패하였습니다.");
+      throw new NotFoundError("댓글 조회에 실패하였습니다.");
+      // throw new Error("댓글 조회에 실패하였습니다.");
     }
-    if (!existComment.userId === userId) {
-      throw new Error("권한이 없습니다.");
+    if (existComment.userId !== userId) {
+      throw new ForbiddenError("권한이 없습니다.");
     }
     const updated = await this.commentsRepository.editComment({
       commentId,
@@ -49,7 +54,7 @@ module.exports = class CommentsService {
     if (!updated) {
       throw new Error("댓글 수정에 실패하였습니다.");
     }
-    return { success: true, message: "댓글이 수정되었습니다." };
+    return { message: "댓글이 수정되었습니다." };
   };
 
   // 댓글 삭제
@@ -58,10 +63,10 @@ module.exports = class CommentsService {
       commentId,
     });
     if (!existComment) {
-      throw new Error("댓글 조회에 실패하였습니다.");
+      throw new NotFoundError("댓글 조회에 실패하였습니다.");
     }
-    if (!existComment.userId === userId) {
-      throw new Error("권한이 없습니다.");
+    if (existComment.userId !== userId) {
+      throw new ForbiddenError("권한이 없습니다.");
     }
     const deleted = await this.commentsRepository.deleteComment({
       commentId,
@@ -69,6 +74,6 @@ module.exports = class CommentsService {
     if (!deleted) {
       throw new Error("댓글 삭제에 실패하였습니다.");
     }
-    return { success: true, message: "댓글이 삭제되었습니다." };
+    return { message: "댓글이 삭제되었습니다." };
   };
 };


### PR DESCRIPTION
- 댓글 도메인은 `res.status().json()` 대신 커스텀에러 적용

> 예시코드
```js
editComment = async ({ userId, commentId, comment }) => {
    const existComment = await this.commentsRepository.getCommentById({
      commentId,
    });
    if (!existComment) {
      throw new NotFoundError("댓글 조회에 실패하였습니다."); // Error이름을 등록하면 상태코드와 함께 에러가 반환됩니다. (status. json 안써도 됨)
    }
    if (existComment.userId !== userId) {
      throw new ForbiddenError("권한이 없습니다."); // Error이름을 등록하면 상태코드와 함께 에러가 반환됩니다. (status. json 안써도 됨)
    }
    const updated = await this.commentsRepository.editComment({
      commentId,
      comment,
    });
    if (!updated) {
      throw new Error("댓글 수정에 실패하였습니다.");
    }
    return { message: "댓글이 수정되었습니다." };
  };
```